### PR TITLE
MOD: latex-extra auctex version check 13+

### DIFF
--- a/latex-extra.el
+++ b/latex-extra.el
@@ -129,7 +129,7 @@
 
 (require 'tex)
 (require 'latex)
-(unless (string-prefix-p "13" AUCTeX-version)
+(if (< (string-to-number (substring AUCTeX-version 0 2)) 13)
   (require 'tex-buf))
 (require 'texmathp)
 (require 'cl-lib)


### PR DESCRIPTION
The recent auctex upgrade to version 14 broke the version check previously implemented, resulting in an erroneous load of `tex-buf`.